### PR TITLE
add .gitattribute to enforce lf line ending for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Linux/*/*.sh text eol=lf


### PR DESCRIPTION
add .gitattribute to enforce LF line ending for shell scripts